### PR TITLE
fix screen reloading in infinite loop

### DIFF
--- a/source/feathers/controls/supportClasses/BaseScreenNavigator.as
+++ b/source/feathers/controls/supportClasses/BaseScreenNavigator.as
@@ -956,7 +956,9 @@ package feathers.controls.supportClasses
 			}
 			else if(this._nextScreenID !== null)
 			{
-				this.showScreenInternal(this._nextScreenID, this._nextScreenTransition);
+				var next:String = this._nextScreenID;
+				this._nextScreenID = null;
+				this.showScreenInternal(next, this._nextScreenTransition);
 			}
 
 			this._nextScreenID = null;


### PR DESCRIPTION
fix issue where BaseScreenNavigator could get caught in infinite loop after calling 'popToRootScreenAndReplace()' from a custom class that extends StackScreenNavigator, due to `_nextScreenID` not getting cleared.